### PR TITLE
kalai_RDKShell_v1

### DIFF
--- a/0001-rdkservices-RDKShell.patch
+++ b/0001-rdkservices-RDKShell.patch
@@ -1,0 +1,9 @@
+Index: git/RDKShell/RDKShell.config
+===================================================================
+--- git.orig/RDKShell/RDKShell.config
++++ git/RDKShell/RDKShell.config
+@@ -1,5 +1,5 @@
+set (autostart ${PLUGIN_RDKSHELL_AUTOSTART})
+-set (preconditions Platform)
++set (preconditions Internet)
+set (callsign "org.rdk.RDKShell")

--- a/rdkservices_git.bbappend
+++ b/rdkservices_git.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+           file://0001-rdkservices-RDKShell.patch \
+           "


### PR DESCRIPTION
Change the precondition of RDKshell which is part of thunder service from 'Platform' to 'Internet' subsystem.

Created a new append file for rdkservices in the layer "meta-rdk" in the name of  rdkservices_git.bbappend and added new patch which is created for changing preconditions of rdkshell to internet subsystem into this appendfile.

